### PR TITLE
Expose GKPlayer.playerID in the c# bindings

### DIFF
--- a/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/GKPlayer.cs
+++ b/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/GKPlayer.cs
@@ -33,6 +33,11 @@ namespace Apple.GameKit
         public string TeamPlayerId => Interop.GKPlayer_GetTeamPlayerId(Pointer);
 
         /// <summary>
+        /// A unique identifier for a player of the game.
+        /// </summary>
+        public string DeprecatedPlayerId => Interop.GKPlayer_GetDeprecatedPlayerId(Pointer);
+
+        /// <summary>
         /// Returns a Boolean value depending on whether the game and Team ID for this player are persistent or unique to this game instance.
         /// </summary>
         public bool ScopedIdsArePersistent => Interop.GKPlayer_GetScopedIdsArePersistent(Pointer);
@@ -107,6 +112,8 @@ namespace Apple.GameKit
             public static extern string GKPlayer_GetGamePlayerId(IntPtr pointer);
             [DllImport(InteropUtility.DLLName)]
             public static extern string GKPlayer_GetTeamPlayerId(IntPtr pointer);
+            [DllImport(InteropUtility.DLLName)]
+            public static extern string GKPlayer_GetDeprecatedPlayerId(IntPtr pointer);
             [DllImport(InteropUtility.DLLName)]
             public static extern bool GKPlayer_GetScopedIdsArePersistent(IntPtr pointer);
             [DllImport(InteropUtility.DLLName)]

--- a/plug-ins/Apple.GameKit/Native/GameKitWrapper/GKPlayer.swift
+++ b/plug-ins/Apple.GameKit/Native/GameKitWrapper/GKPlayer.swift
@@ -28,6 +28,16 @@ public func GKPlayer_GetTeamPlayerId
     return player.teamPlayerID.toCharPCopy();
 }
 
+@_cdecl("GKPlayer_GetDeprecatedPlayerId")
+public func GKPlayer_GetDeprecatedPlayerId
+(
+    pointer : UnsafeMutablePointer<GKPlayer>
+) -> char_p
+{
+    let player = pointer.takeUnretainedValue();
+    return player.playerID.toCharPCopy();
+}
+
 @_cdecl("GKPlayer_GetScopedIDsArePersistent")
 public func GKPlayer_GetScopedIDsArePersistent
 (


### PR DESCRIPTION
Allows access to the deprecated playerId field. We need this in order to facilitate a migration to the new identifiers without players losing access to their game accounts.